### PR TITLE
v0.6.2: Settings backwards compatibility patch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,6 @@ Dockerfile
 docker-compose.*
 *.db
 
-# Include the default settings.json
+# Include the default settings and example post
 !/content/settings.json
 !/content/posts/syntax-examples.md

--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,10 @@ docker-dev
 !content/posts/intro-to-markdown.md
 !/content/posts/benefits-of-writing-markdown.md
 !/content/posts/syntax-examples.md
+
+# env files
 *.env
 .env.local
+
+# todo list
+todo.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,7 +286,7 @@ Minor changes to caching and dynamic rendering
 - **Moved dynamic rendering config** from the root layout to route group layouts
 - **Minor Dockerfile updates** including adding an example post to the base image
 
-## v0.6.2 -- todo
+## v0.6.2 -- April 19, 2025
 
 Add backwards compatibility support to blog settings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,3 +285,16 @@ Minor changes to caching and dynamic rendering
 
 - **Moved dynamic rendering config** from the root layout to route group layouts
 - **Minor Dockerfile updates** including adding an example post to the base image
+
+## v0.6.2 -- todo
+
+Add backwards compatibility support to blog settings
+
+### Added
+
+- **Basic settings validation** when updating the settings file
+
+### Changes
+
+- **Refactor settings page** using a settings editor to update all settings rather individual settings properties
+- **Updated BlogSettingsSchema** to include accurate settings properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN adduser --system --uid 1001 nextjs
 
 COPY --from=builder /writrmd/public ./public
 
-# Copy default content folder (empty posts folder and default settings.json)
+# Copy default content folder (empty posts folder and settings.json)
+VOLUME /writrmd/content
 COPY --from=builder --chown=nextjs:nodejs /writrmd/content /writrmd/content
 
 # Automatically leverage output traces to reduce image size

--- a/app/(routes)/writr/settings/page.tsx
+++ b/app/(routes)/writr/settings/page.tsx
@@ -10,19 +10,6 @@ export default async function Page() {
   return (
     <>
       <SettingsEditor settings={settings} />
-
-      {/* <Header>
-        <h1>Settings</h1>
-      </Header>
-      <hr />
-      <h2>General Settings</h2>
-      <SettingsItem property="name" value={settings.name} label="Name" />
-      <SettingsItem
-        property="summary"
-        value={settings.summary}
-        label="Summary"
-        editor
-      /> */}
     </>
   );
 }

--- a/app/(routes)/writr/settings/page.tsx
+++ b/app/(routes)/writr/settings/page.tsx
@@ -1,6 +1,5 @@
 import { readSettings } from '@/app/lib/actions';
-import Header from '@/app/ui/common/Header';
-import SettingsItem from '@/app/ui/settings/SettingsItem';
+import SettingsEditor from '@/app/ui/editors/SettingsEditor';
 
 export default async function Page() {
   const result = await readSettings();
@@ -10,7 +9,9 @@ export default async function Page() {
 
   return (
     <>
-      <Header>
+      <SettingsEditor settings={settings} />
+
+      {/* <Header>
         <h1>Settings</h1>
       </Header>
       <hr />
@@ -21,7 +22,7 @@ export default async function Page() {
         value={settings.summary}
         label="Summary"
         editor
-      />
+      /> */}
     </>
   );
 }

--- a/app/lib/actions.ts
+++ b/app/lib/actions.ts
@@ -13,6 +13,7 @@ import {
   PostEditorAction,
   BlogSettings,
   Result,
+  DefaultSettings,
 } from '@/app/lib/definitions';
 import { includes } from '@/app/lib/helpers';
 
@@ -202,21 +203,26 @@ export async function savePost(
 }
 
 /**
- * Asynchronously read app settings using an internal worker queue
+ * Asynchronously read app settings
  * @returns Returns a promise resolves to a successful result object with the current settings or rejects with an unsuccessful result object
  */
-// todo: add fallback values for new settings properties
 export async function readSettings(): Promise<Result<BlogSettings>> {
   try {
     const data = await fs.readFile(`${rootDir}/content/${settingsFile}`, {
       encoding: 'utf-8',
     });
-    const settings = JSON.parse(data) as BlogSettings;
+
+    // Parse and provide fallback values for settings
+    const json = JSON.parse(data) as BlogSettings;
+    const settings = { ...DefaultSettings, ...json };
 
     return { success: true, data: settings };
   } catch (error) {
     console.error(error);
-    return { success: false, error: 'Server error' };
+    return {
+      success: false,
+      error: 'Unable to read settings. Try again later.',
+    };
   }
 }
 

--- a/app/lib/actions.ts
+++ b/app/lib/actions.ts
@@ -212,10 +212,15 @@ export async function readSettings(): Promise<Result<BlogSettings>> {
       encoding: 'utf-8',
     });
 
+    // Handle empty settings files
+    if (!data) {
+      // Provide fallback settings if settings json is empty
+      return { success: true, data: DefaultSettings };
+    }
+
     // Parse and provide fallback values for settings
     const json = JSON.parse(data) as BlogSettings;
     const settings = { ...DefaultSettings, ...json };
-
     return { success: true, data: settings };
   } catch (error) {
     console.error(error);

--- a/app/lib/actions.ts
+++ b/app/lib/actions.ts
@@ -231,6 +231,7 @@ export async function readSettings(): Promise<Result<BlogSettings>> {
   }
 }
 
+
 export async function UpdateSettings(
   _: Result<BlogSettings>,
   formData: FormData
@@ -245,7 +246,7 @@ export async function UpdateSettings(
   if (!results.success) {
     return {
       success: false,
-      error: 'Invalid settings values',
+      error: 'Invalid settings properties. Please try again.',
     } as Result<BlogSettings>;
   }
 

--- a/app/lib/schemas.ts
+++ b/app/lib/schemas.ts
@@ -20,8 +20,6 @@ export const CredentialsSchema = z.object({
 });
 
 export const BlogSettingsSchema = z.object({
-  initialized: z.boolean(),
-  blogName: z.string().optional(),
-  blogSummary: z.string(),
-  icon: z.string().optional(),
+  name: z.string().min(5),
+  summary: z.string().min(25),
 });

--- a/app/ui/common/Icon.tsx
+++ b/app/ui/common/Icon.tsx
@@ -1,7 +1,7 @@
 import * as icons from 'react-feather';
 
 export default function Icon({
-  size = 16,
+  size = 18,
   ...props
 }: {
   size?: number;

--- a/app/ui/common/Icon.tsx
+++ b/app/ui/common/Icon.tsx
@@ -1,6 +1,12 @@
 import * as icons from 'react-feather';
 
-export default function Icon(props: { name: keyof typeof icons }) {
+export default function Icon({
+  size = 16,
+  ...props
+}: {
+  size?: number;
+  name: keyof typeof icons;
+}) {
   const IconComponent = icons[props.name];
-  return <IconComponent />;
+  return <IconComponent size={size} />;
 }

--- a/app/ui/common/StyledButton.tsx
+++ b/app/ui/common/StyledButton.tsx
@@ -10,11 +10,12 @@ export default function StyledButton(props: {
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   ref?: React.RefObject<HTMLButtonElement | null>;
   alt?: string;
+  type?: 'button' | 'submit' | 'reset';
 }) {
   return (
     <button
       ref={props.ref}
-      type="button"
+      type={props.type || 'button'}
       className={clsx(
         `${styles.base}`,
         props.variation && `${styles[props.variation]}`,

--- a/app/ui/editors/SettingsEditor.module.css
+++ b/app/ui/editors/SettingsEditor.module.css
@@ -1,0 +1,36 @@
+.heading_container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.item_container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.item_label {
+  display: flex;
+  gap: var(--spacing-small);
+  justify-content: flex-start;
+  align-items: center;
+  padding-block: var(--spacing-xs);
+  font-weight: var(--weight-bold);
+}
+
+.item_value {
+  height: calc(var(--spacing-large) * 1.25);
+  display: flex;
+  align-items: center;
+}
+
+.item_input {
+  width: 100%;
+  height: 100%;
+  padding-left: var(--spacing-small);
+  background-color: var(--clr-bg-2);
+  color: var(--clr-fg-1);
+  border: none;
+  border-radius: var(--border-radius);
+}

--- a/app/ui/editors/SettingsEditor.module.css
+++ b/app/ui/editors/SettingsEditor.module.css
@@ -4,6 +4,29 @@
   align-items: center;
 }
 
+.error_message {
+  color: var(--clr-danger);
+}
+
+.actions {
+  display: flex;
+  gap: var(--spacing-small);
+}
+
+.actions button {
+  padding: var(--spacing-small);
+  border-radius: var(--border-radius);
+  border: none;
+}
+
+.actions button:hover {
+  background-color: var(--clr-bg-2);
+}
+
+.hidden {
+  display: none;
+}
+
 .item_container {
   display: flex;
   flex-direction: column;
@@ -17,6 +40,7 @@
   align-items: center;
   padding-block: var(--spacing-xs);
   font-weight: var(--weight-bold);
+  font-size: var(--font-large);
 }
 
 .item_value {

--- a/app/ui/editors/SettingsEditor.tsx
+++ b/app/ui/editors/SettingsEditor.tsx
@@ -7,6 +7,7 @@ import StyledButton from '@/app/ui/common/StyledButton';
 import { useActionState, useEffect, useState } from 'react';
 import styles from './SettingsEditor.module.css';
 import { UpdateSettings } from '@/app/lib/actions';
+import clsx from 'clsx';
 
 /*** COMPONENT STARTS HERE ***/
 export default function SettingsEditor(props: { settings: BlogSettings }) {
@@ -20,29 +21,50 @@ export default function SettingsEditor(props: { settings: BlogSettings }) {
     if (state.success) setViewing(true);
   }, [state]);
 
+  function handleClick() {
+    setViewing((viewing) => !viewing);
+  }
+
   return (
     <form action={action}>
       <Header>
         <div className={styles.heading_container}>
           <div>
-            <h1 style={{ color: state.success ? 'green' : 'red' }}>Settings</h1>
-            {!state.success && <p>{state.error}</p>}
+            <h1>Settings</h1>
           </div>
-          <div>
-            {viewing ? (
+          {!state.success && (
+            <p className={styles.error_message}>{state.error}</p>
+          )}
+          <div className={styles.actions}>
+            {/* {viewing ? (
               <StyledButton onClick={() => setViewing(false)}>
-                <Icon name={'Edit'} />
+                <Icon name="Edit" />
               </StyledButton>
             ) : (
               <>
-                <StyledButton onClick={() => setViewing(true)}>
+                <StyledButton type="submit">
+                  <Icon name="Save" />
+                </StyledButton>
+                <StyledButton
+                  onClick={() => {
+                    console.log('clicked cancel');
+                    setViewing(true);
+                  }}
+                >
                   <Icon name="XCircle" />
                 </StyledButton>
-                <StyledButton type="submit">
-                  <Icon name={'Save'} />
-                </StyledButton>
               </>
-            )}
+            )} */}
+            <StyledButton
+              type="submit"
+              onClick={handleClick}
+              className={clsx(viewing && `${styles.hidden}`)}
+            >
+              <Icon name="Save" />
+            </StyledButton>
+            <StyledButton onClick={handleClick} type="reset">
+              <Icon name={viewing ? 'Edit' : 'XCircle'} />
+            </StyledButton>
           </div>
         </div>
       </Header>

--- a/app/ui/editors/SettingsEditor.tsx
+++ b/app/ui/editors/SettingsEditor.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { BlogSettings } from '@/app/lib/definitions';
+import Header from '@/app/ui/common/Header';
+import Icon from '@/app/ui/common/Icon';
+import StyledButton from '@/app/ui/common/StyledButton';
+import { useActionState, useEffect, useState } from 'react';
+import styles from './SettingsEditor.module.css';
+import { UpdateSettings } from '@/app/lib/actions';
+
+/*** COMPONENT STARTS HERE ***/
+export default function SettingsEditor(props: { settings: BlogSettings }) {
+  const [viewing, setViewing] = useState(true);
+  const [state, action] = useActionState(UpdateSettings, {
+    success: true,
+    data: props.settings,
+  });
+
+  useEffect(() => {
+    if (state.success) setViewing(true);
+  }, [state]);
+
+  return (
+    <form action={action}>
+      <Header>
+        <div className={styles.heading_container}>
+          <div>
+            <h1 style={{ color: state.success ? 'green' : 'red' }}>Settings</h1>
+            {!state.success && <p>{state.error}</p>}
+          </div>
+          <div>
+            {viewing ? (
+              <StyledButton onClick={() => setViewing(false)}>
+                <Icon name={'Edit'} />
+              </StyledButton>
+            ) : (
+              <>
+                <StyledButton onClick={() => setViewing(true)}>
+                  <Icon name="XCircle" />
+                </StyledButton>
+                <StyledButton type="submit">
+                  <Icon name={'Save'} />
+                </StyledButton>
+              </>
+            )}
+          </div>
+        </div>
+      </Header>
+      <Item
+        property={'name'}
+        label="Blog Name"
+        value={props.settings.name}
+        viewing={viewing}
+      />
+      <Item
+        property="summary"
+        label="Blog Summary"
+        value={props.settings.summary}
+        viewing={viewing}
+      />
+    </form>
+  );
+}
+
+function Item<K extends keyof BlogSettings>(props: {
+  property: K;
+  value: BlogSettings[K];
+  label: string;
+  viewing: boolean;
+}) {
+  return (
+    <div className={styles.item_container}>
+      <label htmlFor={props.property} className={styles.item_label}>
+        {props.label}
+      </label>
+      <div className={styles.item_value}>
+        {props.viewing ? (
+          <div>{props.value}</div>
+        ) : (
+          <input
+            type="text"
+            defaultValue={props.value}
+            className={styles.item_input}
+            name={props.property}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -15,7 +15,7 @@ services:
       - ADMIN_USERNAME=admin
       - ADMIN_PASSWORD=12345
     volumes:
-      - writrmd-data:/writrmd/content
+      - writrmd_dev_data:/writrmd/content
 
   caddy:
     image: caddy:latest
@@ -35,7 +35,7 @@ services:
 volumes:
   caddy_data:
   caddy_config:
-  writrmd-data:
+  writrmd_dev_data:
 
 networks:
   writrmd_network:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "writrmd",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
This patch adds backwards compatibility support for previous Writr.md settings versions. This is accomplished by providing fallback values for new settings properties and adding an 'all or nothing' approach to updating settings values. This patch closes issue #70 